### PR TITLE
Add label to the secret

### DIFF
--- a/scripts/generate-cert.sh
+++ b/scripts/generate-cert.sh
@@ -10,3 +10,4 @@ openssl req -out tmp/tls.csr -newkey rsa:2048 -nodes -keyout tmp/tls.key -subj "
 openssl x509 -req -days 365 -CA tmp/ca-tls.pem -CAkey tmp/ca-key.pem -CAcreateserial -in tmp/tls.csr -out tmp/tls.crt
 oc delete secret cert-encryption -n sealedsecrets
 oc create secret generic cert-encryption  -n sealedsecrets --from-file=tmp/tls.key --from-file=tmp/tls.crt --from-file=tmp/ca-tls.pem
+oc label secret cert-encryption -n sealedsecrets sealedsecrets.bitnami.com/sealed-secrets-key=active


### PR DESCRIPTION
The secret requires the label. 

This might not be required for installation (as the helm chart probably labels it) but it is required for the renewal (where the previous secret with the label is deleted in line #11) and the new one is expected to be used by the controller